### PR TITLE
Add script to disable apt auto upgrade

### DIFF
--- a/disable-apt-autoupgrade.sh
+++ b/disable-apt-autoupgrade.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eu
+
+sudo systemctl mask apt-daily.service
+sudo systemctl mask apt-daily.timer
+sudo systemctl mask apt-daily-upgrade.service
+sudo systemctl mask apt-daily-upgrade.timer
+sudo sed -i -e 's/Update-Package-Lists "1"/Update-Package-Lists "0"/g' -e 's/Unattended-Upgrade "1"/Unattended-Upgrade "0"/g' /etc/apt/apt.conf.d/20auto-upgrades


### PR DESCRIPTION
起動時に`Could not get lock /var/lib/dpkg/lock`とエラーが出る問題に対処するために自動でアップグレードされないようにするスクリプトを追加しました。