### PR TITLE
Fix packages.ros.org GPG key

### DIFF
--- a/install-ros-melodic.sh
+++ b/install-ros-melodic.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Reference sites
 # https://www.stereolabs.com/blog/ros-and-nvidia-jetson-nano/
@@ -7,7 +7,7 @@ echo "[Add the ROS repository]"
 if [ ! -e /etc/apt/sources.list.d/ros-latest.list ]; then
     sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 fi
-sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 echo "[Update the package]"
 sudo apt-get update


### PR DESCRIPTION
`packages.ros.org`のGPG keyがアップデートされ、以前のGPG keyで`packages.ros.org`からパッケージをインストールしようとするとエラー（`NO_PUBKEY F42ED6FBAB17C654`）が出るようになったのでその問題を修正するためのPRです。

https://discourse.ros.org/t/new-gpg-keys-deployed-for-packages-ros-org/9454

関連PR: https://github.com/ros/rosdistro/pull/21492
