### PR TITLE
Replaced the old key

### DIFF
--- a/install-ros-melodic.sh
+++ b/install-ros-melodic.sh
@@ -7,7 +7,8 @@ echo "[Add the ROS repository]"
 if [ ! -e /etc/apt/sources.list.d/ros-latest.list ]; then
     sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 fi
-sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+#sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 echo "[Update the package]"
 sudo apt-get update


### PR DESCRIPTION
## Purpose

Since the key could not be loaded, I checked the original site and found that the keyserver had been changed, so I fixed it.

## Effect

Setup is completed successfully.

## Test

Test command: install-ros-merodic.sh

## Test Environment

JetPack 4.5.1

### Hardware

Jetson Nano B01

### Software(Library)

None

## Memo
